### PR TITLE
Add ripgrep keymap in lua

### DIFF
--- a/nvim/lua/user/mappings.lua
+++ b/nvim/lua/user/mappings.lua
@@ -26,3 +26,9 @@ vim.cmd([[
 nnoremap <leader>ff <cmd>Telescope find_files<cr>
 nnoremap <leader>fg <cmd>Telescope live_grep<cr>
 ]])
+
+-- With lua:
+-- vim.api.nvim_set_keymap("n", "<leader>ff", '<cmd>Telescope find_files<cr>', opts)
+-- vim.api.nvim_set_keymap("n", "<leader>fg", '<cmd>Telescope live_grep<cr>', opts)
+
+


### PR DESCRIPTION
Rewrite keymaps in pure ```lua``` script instead of ```vim.cmd()```